### PR TITLE
Add --label flag to search and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ gmail search "in:inbox"
 gmail search "from:boss@company.com is:unread"
 gmail search "has:attachment filename:pdf after:2024/01/01"
 gmail search "label:Work subject:urgent" --max 50
+gmail search --label Label_123              # filter by label ID (from 'labels list')
+gmail search "is:unread" --label INBOX      # combine query with label filter
 ```
 
 ### Read threads
@@ -142,8 +144,9 @@ CONFIG COMMANDS
 
 GMAIL COMMANDS
 
-  gmail search <query> [--max N] [--page TOKEN]
-      Search threads. Returns: thread ID, date, sender, subject, labels.
+  gmail search [query] [--max N] [--page TOKEN] [--label L]
+      Search threads. Query uses Gmail syntax, --label filters by name or ID.
+      Returns: thread ID, date, sender, subject, labels.
 
   gmail thread <threadId> [--download]
       Get full thread. --download saves attachments.

--- a/src/gmail-service.ts
+++ b/src/gmail-service.ts
@@ -151,13 +151,20 @@ export class GmailService {
 		return this.gmailClients.get(email)!;
 	}
 
-	async searchThreads(email: string, query: string, maxResults = 10, pageToken?: string): Promise<ThreadSearchResult> {
+	async searchThreads(
+		email: string,
+		query: string,
+		maxResults = 10,
+		pageToken?: string,
+		labelIds?: string[],
+	): Promise<ThreadSearchResult> {
 		const gmail = this.getGmailClient(email);
 		const response = await gmail.users.threads.list({
 			userId: "me",
-			q: query,
+			q: query || undefined,
 			maxResults,
 			pageToken,
+			labelIds: labelIds?.length ? labelIds : undefined,
 		});
 
 		const threads = response.data.threads || [];


### PR DESCRIPTION
## Summary
- Add `--label` flag to search command to filter by label name or ID
- Update README with label color documentation
- Update README command reference to match CLI help

## Changes
1. **Search by label**: `gmail search --label INBOX` or `gmail search --label Label_123`
   - Accepts label name or ID (resolved automatically)
   - Multiple labels supported: `--label INBOX -l UNREAD`
   - Combinable with query: `gmail search "is:unread" --label Label_123`

2. **Documentation updates**:
   - Added `--label` flag examples to README
   - Updated command reference to show `[query]` as optional
   - Added label color examples to "Manage labels" section

## Test plan
- [x] Search by label name only: `gmail search --label INBOX`
- [x] Search by label ID only: `gmail search --label Label_117`
- [x] Search with query + label: `gmail search is:unread --label INBOX`
- [x] Multiple labels: `gmail search --label INBOX -l UNREAD`
- [x] CLI help matches README command reference