### PR TITLE
Add env var credentials (GMAIL_CLIENT_ID/SECRET/REFRESH_TOKEN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ After [setup](#setup-one-time), search your inbox:
 gmail search "in:inbox is:unread" --max 10
 ```
 
+### Environment variable credentials
+
+Skip file-based setup entirely by passing OAuth credentials as env vars:
+
+```bash
+GMAIL_CLIENT_ID=xxx GMAIL_CLIENT_SECRET=xxx GMAIL_REFRESH_TOKEN=xxx GMAIL_ACCOUNT=you@gmail.com \
+  gmail search "in:inbox" --max 10
+```
+
+| Env var | Required | Description |
+|---------|----------|-------------|
+| `GMAIL_CLIENT_ID` | Yes | OAuth client ID |
+| `GMAIL_CLIENT_SECRET` | Yes | OAuth client secret |
+| `GMAIL_REFRESH_TOKEN` | Yes | OAuth refresh token |
+| `GMAIL_ACCOUNT` | Yes | Email address |
+| `GMAIL_PROXY` | No | Route through security proxy (unix socket path or host:port) |
+
+When set, credentials stay in memory — no files are read or written. This is the recommended approach for automated environments and sprites.
+
 ## Setup (one-time)
 
 ### 1. Create OAuth credentials

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smcllns/gmail",
-	"version": "0.8.1",
+	"version": "0.9.0",
 	"description": "Minimal Gmail CLI with restricted scopes for Claude Code and other agents",
 	"type": "module",
 	"bin": {

--- a/plans/env-var-credentials.md
+++ b/plans/env-var-credentials.md
@@ -1,0 +1,100 @@
+# PR: Env var support for OAuth credentials
+
+Implements https://github.com/smcllns/gmail/issues/21
+
+## Motivation
+
+The proxy currently reads tokens from files, then deletes them. This works but is fragile (race conditions, file permission issues — we hit EACCES during sprite testing). With env var support, the entire credential flow is in-memory: env vars → GmailService → Gmail API. No files touched.
+
+This also makes sprite setup simpler: `sprite exec -env "GMAIL_REFRESH_TOKEN=xxx" gmail search "in:inbox"` just works.
+
+## Env vars
+
+| Var | Required | Description |
+|-----|----------|-------------|
+| `GMAIL_CLIENT_ID` | Yes (with refresh token) | OAuth client ID |
+| `GMAIL_CLIENT_SECRET` | Yes (with refresh token) | OAuth client secret |
+| `GMAIL_REFRESH_TOKEN` | Yes | OAuth refresh token |
+| `GMAIL_ACCOUNT` | No | Email address (default: derived from token or first configured account) |
+
+When all three required vars are set, the CLI skips file-based config entirely. No `~/.gmail-cli/` needed.
+
+## Changes
+
+### 1. `src/cli.ts` — env var account bootstrap
+
+Early in CLI startup (before command dispatch), check for env vars:
+
+```typescript
+if (process.env.GMAIL_REFRESH_TOKEN) {
+  const email = process.env.GMAIL_ACCOUNT || opts.account;
+  if (!email) {
+    // Could derive from token via /userinfo endpoint, but simpler to require it
+    console.error("GMAIL_ACCOUNT or --account required when using env var credentials");
+    process.exit(1);
+  }
+  gmail.setAccountTokens({
+    email,
+    oauth2: {
+      clientId: process.env.GMAIL_CLIENT_ID!,
+      clientSecret: process.env.GMAIL_CLIENT_SECRET!,
+      refreshToken: process.env.GMAIL_REFRESH_TOKEN!,
+    },
+    scopes: ["https://www.googleapis.com/auth/gmail.modify", "https://www.googleapis.com/auth/gmail.labels"],
+  });
+}
+```
+
+### 2. `src/gmail-service.ts` — skip `ensureAnyScope` when proxied
+
+When `GMAIL_PROXY` is set, skip `ensureAnyScope` (the proxy enforces scope, not the CLI). This fixes the issue both Pi and Gemini flagged in PR #22.
+
+```typescript
+private ensureAnyScope(email: string, required: string[], action: string): void {
+  if (process.env.GMAIL_PROXY) return; // proxy enforces scope
+  // ... existing logic
+}
+```
+
+### 3. `src/gmail-service.ts` — skip `getAccount` for proxy mode
+
+When `GMAIL_PROXY` is set and no account exists locally, don't throw. The proxy handles auth.
+
+### 4. README.md — document env vars
+
+Add env var section with examples for sprite and local use.
+
+## How the proxy benefits
+
+With this change, `sprite-start.sh` simplifies from:
+
+```bash
+# Before: write file, chown, proxy reads & deletes
+echo "$TOKEN" > /tmp/oauth-token
+chown proxy:proxy /tmp/oauth-token
+su proxy -c "bun run proxy --token-file /tmp/oauth-token ..."
+```
+
+To:
+
+```bash
+# After: pure env var, zero files
+GMAIL_REFRESH_TOKEN=$TOKEN GMAIL_CLIENT_ID=$ID GMAIL_CLIENT_SECRET=$SECRET \
+  su proxy -c "bun run proxy ..."
+```
+
+And the proxy itself can use `GmailService` directly instead of raw fetch + token management:
+
+```typescript
+// Proxy can bootstrap from env vars like any other consumer
+const gmail = new GmailService();
+// env vars already loaded by CLI bootstrap
+```
+
+## Testing
+
+- [ ] `GMAIL_REFRESH_TOKEN=xxx GMAIL_ACCOUNT=test@gmail.com gmail search "in:inbox"` works
+- [ ] Without env vars, existing file-based flow still works
+- [ ] `GMAIL_PROXY` + env vars work together (proxy mode, no local account needed)
+- [ ] Missing required env vars give clear error messages
+- [ ] `--account` flag overrides `GMAIL_ACCOUNT` env var

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,10 +137,15 @@ function getAccount(args: string[]): { account: string; remainingArgs: string[] 
 		return { account, remainingArgs };
 	}
 
-	// Use default account
+	// Use GMAIL_ACCOUNT env var, then default account
+	const envAccount = process.env.GMAIL_ACCOUNT;
+	if (envAccount) {
+		return { account: envAccount, remainingArgs: args };
+	}
+
 	const defaultAccount = service.getDefaultAccount();
 	if (!defaultAccount) {
-		error("No default account configured. Run: gmail config default <email>");
+		error("No default account configured. Set GMAIL_ACCOUNT env var or run: gmail config default <email>");
 	}
 	return { account: defaultAccount, remainingArgs: args };
 }
@@ -161,6 +166,33 @@ async function main() {
 	}
 
 	service = new GmailService(configDir ? { configDir } : undefined);
+
+	// Bootstrap from env vars if available (credentials stay in memory, no files)
+	const hasAnyGmailEnv = process.env.GMAIL_CLIENT_ID || process.env.GMAIL_CLIENT_SECRET || process.env.GMAIL_REFRESH_TOKEN;
+	if (hasAnyGmailEnv && !process.env.GMAIL_REFRESH_TOKEN) {
+		error("Incomplete env var credentials: GMAIL_REFRESH_TOKEN is required when GMAIL_CLIENT_ID or GMAIL_CLIENT_SECRET is set");
+	}
+	if (process.env.GMAIL_REFRESH_TOKEN) {
+		const clientId = process.env.GMAIL_CLIENT_ID;
+		const clientSecret = process.env.GMAIL_CLIENT_SECRET;
+		if (!clientId || !clientSecret) {
+			error("GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET required when using GMAIL_REFRESH_TOKEN");
+		}
+		// Account from env var or --account flag
+		const accountIdx = args.indexOf("--account");
+		const email = process.env.GMAIL_ACCOUNT
+			|| args.find(a => a.startsWith("--account="))?.split("=")[1]
+			|| (accountIdx !== -1 ? args[accountIdx + 1] : undefined);
+		if (!email) {
+			error("GMAIL_ACCOUNT or --account required when using env var credentials");
+		}
+		// setAccountTokens stores in memory only — never writes to disk
+		service.setAccountTokens({
+			email,
+			oauth2: { clientId, clientSecret, refreshToken: process.env.GMAIL_REFRESH_TOKEN },
+			scopes: DEFAULT_GMAIL_SCOPES,
+		});
+	}
 
 	const first = args[0];
 	const rest = args.slice(1);
@@ -203,8 +235,10 @@ async function main() {
 				break;
 			case "send":
 				handleRestrictedSend();
+				break;
 			case "delete":
 				handleRestrictedDelete();
+				break;
 			case "url":
 				handleUrl(account, commandArgs);
 				break;

--- a/src/gmail-service.ts
+++ b/src/gmail-service.ts
@@ -393,6 +393,7 @@ export class GmailService {
 	}
 
 	private ensureAnyScope(email: string, required: string[], action: string): void {
+		if (process.env.GMAIL_PROXY) return; // Proxy enforces scope, not the CLI
 		const account = this.getAccount(email);
 		if (!account.scopes || account.scopes.length === 0) {
 			// Security: preserve compatibility for legacy accounts without recorded scopes.


### PR DESCRIPTION
Implements #21

## What

Accept OAuth credentials via environment variables so the CLI works without file-based config. When set, credentials stay in memory — no files are read or written.

```bash
GMAIL_CLIENT_ID=x GMAIL_CLIENT_SECRET=x GMAIL_REFRESH_TOKEN=x GMAIL_ACCOUNT=you@gmail.com \
  gmail search "in:inbox" --max 10
```

## Changes

### `src/cli.ts`
- Check env vars at startup, bootstrap via `setAccountTokens()` (in-memory only)
- `GMAIL_ACCOUNT` env var as fallback for account resolution (supports `--account` and `--account=` syntax)
- Partial env var detection: helpful error if some but not all vars are set

### `src/gmail-service.ts`
- Skip `ensureAnyScope` when `GMAIL_PROXY` is set (proxy enforces scope, not the CLI) — fixes issue flagged in PR #22 review

### `README.md`
- New env var credentials section with table
- `GMAIL_PROXY` added to env var table

### Version bump: 0.8.1 → 0.9.0

## Gemini 3.1 Pro Review

Two rounds of review via opencode. Findings addressed:

| Finding | Severity | Resolution |
|---------|----------|------------|
| `--account` flag bypass when using env vars | HIGH | Account now resolved from env var OR `--account`/`--account=` arg |
| setAccountTokens might write to disk | HIGH | Confirmed in-memory only. Added code comment. |
| GMAIL_PROXY not documented | MEDIUM | Added to env var table in README |
| Brittle `--account` parsing (no `=` support) | MEDIUM | Now handles both `--account val` and `--account=val` |
| Partial env var silent fallback | LOW | Added error when some but not all GMAIL_ vars are set |

**Gemini verdict after fixes: COMMENT → address parsing makes it APPROVE**