### PR TITLE
Remove all unintentional `any` types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smcllns/gmail",
-	"version": "0.8.1",
+	"version": "0.9.1",
 	"description": "Minimal Gmail CLI with restricted scopes for Claude Code and other agents",
 	"type": "module",
 	"bin": {

--- a/plans/env-var-credentials.md
+++ b/plans/env-var-credentials.md
@@ -1,0 +1,100 @@
+# PR: Env var support for OAuth credentials
+
+Implements https://github.com/smcllns/gmail/issues/21
+
+## Motivation
+
+The proxy currently reads tokens from files, then deletes them. This works but is fragile (race conditions, file permission issues — we hit EACCES during sprite testing). With env var support, the entire credential flow is in-memory: env vars → GmailService → Gmail API. No files touched.
+
+This also makes sprite setup simpler: `sprite exec -env "GMAIL_REFRESH_TOKEN=xxx" gmail search "in:inbox"` just works.
+
+## Env vars
+
+| Var | Required | Description |
+|-----|----------|-------------|
+| `GMAIL_CLIENT_ID` | Yes (with refresh token) | OAuth client ID |
+| `GMAIL_CLIENT_SECRET` | Yes (with refresh token) | OAuth client secret |
+| `GMAIL_REFRESH_TOKEN` | Yes | OAuth refresh token |
+| `GMAIL_ACCOUNT` | No | Email address (default: derived from token or first configured account) |
+
+When all three required vars are set, the CLI skips file-based config entirely. No `~/.gmail-cli/` needed.
+
+## Changes
+
+### 1. `src/cli.ts` — env var account bootstrap
+
+Early in CLI startup (before command dispatch), check for env vars:
+
+```typescript
+if (process.env.GMAIL_REFRESH_TOKEN) {
+  const email = process.env.GMAIL_ACCOUNT || opts.account;
+  if (!email) {
+    // Could derive from token via /userinfo endpoint, but simpler to require it
+    console.error("GMAIL_ACCOUNT or --account required when using env var credentials");
+    process.exit(1);
+  }
+  gmail.setAccountTokens({
+    email,
+    oauth2: {
+      clientId: process.env.GMAIL_CLIENT_ID!,
+      clientSecret: process.env.GMAIL_CLIENT_SECRET!,
+      refreshToken: process.env.GMAIL_REFRESH_TOKEN!,
+    },
+    scopes: ["https://www.googleapis.com/auth/gmail.modify", "https://www.googleapis.com/auth/gmail.labels"],
+  });
+}
+```
+
+### 2. `src/gmail-service.ts` — skip `ensureAnyScope` when proxied
+
+When `GMAIL_PROXY` is set, skip `ensureAnyScope` (the proxy enforces scope, not the CLI). This fixes the issue both Pi and Gemini flagged in PR #22.
+
+```typescript
+private ensureAnyScope(email: string, required: string[], action: string): void {
+  if (process.env.GMAIL_PROXY) return; // proxy enforces scope
+  // ... existing logic
+}
+```
+
+### 3. `src/gmail-service.ts` — skip `getAccount` for proxy mode
+
+When `GMAIL_PROXY` is set and no account exists locally, don't throw. The proxy handles auth.
+
+### 4. README.md — document env vars
+
+Add env var section with examples for sprite and local use.
+
+## How the proxy benefits
+
+With this change, `sprite-start.sh` simplifies from:
+
+```bash
+# Before: write file, chown, proxy reads & deletes
+echo "$TOKEN" > /tmp/oauth-token
+chown proxy:proxy /tmp/oauth-token
+su proxy -c "bun run proxy --token-file /tmp/oauth-token ..."
+```
+
+To:
+
+```bash
+# After: pure env var, zero files
+GMAIL_REFRESH_TOKEN=$TOKEN GMAIL_CLIENT_ID=$ID GMAIL_CLIENT_SECRET=$SECRET \
+  su proxy -c "bun run proxy ..."
+```
+
+And the proxy itself can use `GmailService` directly instead of raw fetch + token management:
+
+```typescript
+// Proxy can bootstrap from env vars like any other consumer
+const gmail = new GmailService();
+// env vars already loaded by CLI bootstrap
+```
+
+## Testing
+
+- [ ] `GMAIL_REFRESH_TOKEN=xxx GMAIL_ACCOUNT=test@gmail.com gmail search "in:inbox"` works
+- [ ] Without env vars, existing file-based flow still works
+- [ ] `GMAIL_PROXY` + env vars work together (proxy mode, no local account needed)
+- [ ] Missing required env vars give clear error messages
+- [ ] `--account` flag overrides `GMAIL_ACCOUNT` env var

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 
 import * as fs from "fs";
 import { parseArgs } from "util";
-import { DEFAULT_GMAIL_SCOPES, type EnhancedThread, GmailService, READONLY_GMAIL_SCOPES } from "./gmail-service.js";
+import { DEFAULT_GMAIL_SCOPES, type DownloadedAttachment, type EnhancedThread, GmailService, READONLY_GMAIL_SCOPES } from "./gmail-service.js";
 
 let service!: GmailService;
 
@@ -401,7 +401,7 @@ async function handleThread(account: string, args: string[]) {
 	const result = await service.getThread(account, threadId, download);
 
 	if (download) {
-		const attachments = result as any[];
+		const attachments = result as DownloadedAttachment[];
 		if (attachments.length === 0) {
 			console.log("No attachments");
 		} else {
@@ -593,13 +593,13 @@ async function handleDraft(account: string, args: string[]) {
 		if (lastMessage) {
 			// Get the Message-ID header from the raw message
 			const messageId = lastMessage.payload?.headers?.find(
-				(h: any) => h.name?.toLowerCase() === "message-id"
+				(h) => h.name?.toLowerCase() === "message-id"
 			)?.value;
 			if (messageId) {
 				inReplyTo = messageId;
 				// Build References chain
 				const existingRefs = lastMessage.payload?.headers?.find(
-					(h: any) => h.name?.toLowerCase() === "references"
+					(h) => h.name?.toLowerCase() === "references"
 				)?.value;
 				references = existingRefs ? `${existingRefs} ${messageId}` : messageId;
 			}

--- a/src/gmail-oauth-flow.ts
+++ b/src/gmail-oauth-flow.ts
@@ -2,6 +2,7 @@ import { spawn } from "child_process";
 import * as http from "http";
 import type { AddressInfo } from "net";
 import * as readline from "readline";
+import type { ParsedUrlQuery } from "querystring";
 import * as url from "url";
 import { OAuth2Client } from "google-auth-library";
 
@@ -131,7 +132,7 @@ export class GmailOAuthFlow {
 	}
 
 	private async handleCallback(
-		query: any,
+		query: ParsedUrlQuery,
 		res: http.ServerResponse,
 		resolve: (result: AuthResult) => void,
 	): Promise<void> {
@@ -139,7 +140,7 @@ export class GmailOAuthFlow {
 			res.writeHead(200, { "Content-Type": "text/html" });
 			res.end("<html><body><h1>Authorization cancelled</h1></body></html>");
 			this.cleanup();
-			resolve({ success: false, error: query.error });
+			resolve({ success: false, error: String(query.error) });
 			return;
 		}
 

--- a/src/gmail-proxy-client.ts
+++ b/src/gmail-proxy-client.ts
@@ -3,46 +3,49 @@
  * requests through a Gmail security proxy (unix socket or TCP).
  *
  * Matches the subset of the googleapis API shape used by GmailService.
+ * This is intentionally duck-typed to avoid coupling to googleapis types —
+ * the proxy client is a standalone module with no googleapis dependency.
  */
 
 const API_BASE = "/gmail/v1/users/me";
 
-type FetchOptions = { unix?: string };
+type QueryParams = Record<string, string | number | string[] | undefined>;
 
-function buildFetchOptions(proxyPath: string): { baseUrl: string; fetchOpts: FetchOptions } {
+interface ProxyFetchOptions {
+  method?: string;
+  body?: Record<string, unknown>;
+  query?: QueryParams;
+}
+
+interface GmailApiError extends Error {
+  code: number;
+  response: { status: number; data: string };
+}
+
+function buildFetchOptions(proxyPath: string): { baseUrl: string; unix?: string } {
   if (proxyPath.startsWith("/") || proxyPath.startsWith("./")) {
-    // Unix socket path
-    return {
-      baseUrl: `http://localhost${API_BASE}`,
-      fetchOpts: { unix: proxyPath },
-    };
+    return { baseUrl: `http://localhost${API_BASE}`, unix: proxyPath };
   }
-  // TCP host:port
   const host = proxyPath.includes("://") ? proxyPath : `http://${proxyPath}`;
-  return {
-    baseUrl: `${host}${API_BASE}`,
-    fetchOpts: {},
-  };
+  return { baseUrl: `${host}${API_BASE}` };
 }
 
 async function proxyFetch(
   proxyPath: string,
   path: string,
-  options: { method?: string; body?: any; query?: Record<string, any> } = {},
-): Promise<any> {
-  const { baseUrl, fetchOpts } = buildFetchOptions(proxyPath);
+  options: ProxyFetchOptions = {},
+): Promise<{ data: unknown }> {
+  const { baseUrl, unix } = buildFetchOptions(proxyPath);
 
-  // Build query string
   let url = `${baseUrl}${path}`;
   if (options.query) {
     const params = new URLSearchParams();
     for (const [k, v] of Object.entries(options.query)) {
-      if (v !== undefined && v !== null) {
-        if (Array.isArray(v)) {
-          for (const item of v) params.append(k, String(item));
-        } else {
-          params.set(k, String(v));
-        }
+      if (v === undefined || v === null) continue;
+      if (Array.isArray(v)) {
+        for (const item of v) params.append(k, item);
+      } else {
+        params.set(k, String(v));
       }
     }
     const qs = params.toString();
@@ -56,16 +59,18 @@ async function proxyFetch(
     body = JSON.stringify(options.body);
   }
 
-  const res = await fetch(url, {
+  const fetchInit: RequestInit & { unix?: string } = {
     method: options.method || "GET",
     headers,
     body,
-    ...fetchOpts,
-  } as any);
+  };
+  if (unix) fetchInit.unix = unix;
+
+  const res = await fetch(url, fetchInit as RequestInit);
 
   if (!res.ok) {
     const text = await res.text();
-    const error = new Error(`Gmail API error ${res.status}: ${text}`) as any;
+    const error = new Error(`Gmail API error ${res.status}: ${text}`) as GmailApiError;
     error.code = res.status;
     error.response = { status: res.status, data: text };
     throw error;
@@ -75,7 +80,7 @@ async function proxyFetch(
 }
 
 export function createProxyGmailClient(proxyPath: string) {
-  const pf = (path: string, opts?: any) => proxyFetch(proxyPath, path, opts);
+  const pf = (path: string, opts?: ProxyFetchOptions) => proxyFetch(proxyPath, path, opts);
 
   return {
     users: {
@@ -93,7 +98,7 @@ export function createProxyGmailClient(proxyPath: string) {
         get: (params: { userId: string; id: string }) =>
           pf(`/threads/${params.id}`),
 
-        modify: (params: { userId: string; id: string; requestBody: any }) =>
+        modify: (params: { userId: string; id: string; requestBody: Record<string, unknown> }) =>
           pf(`/threads/${params.id}/modify`, {
             method: "POST",
             body: params.requestBody,
@@ -111,21 +116,21 @@ export function createProxyGmailClient(proxyPath: string) {
       },
 
       labels: {
-        list: (params: { userId: string }) =>
+        list: (_params: { userId: string }) =>
           pf("/labels"),
 
         get: (params: { userId: string; id: string }) =>
           pf(`/labels/${params.id}`),
 
-        create: (params: { userId: string; requestBody: any }) =>
+        create: (params: { userId: string; requestBody: Record<string, unknown> }) =>
           pf("/labels", { method: "POST", body: params.requestBody }),
 
-        update: (params: { userId: string; id: string; requestBody: any }) =>
+        update: (params: { userId: string; id: string; requestBody: Record<string, unknown> }) =>
           pf(`/labels/${params.id}`, { method: "PUT", body: params.requestBody }),
       },
 
       drafts: {
-        create: (params: { userId: string; requestBody: any }) =>
+        create: (params: { userId: string; requestBody: Record<string, unknown> }) =>
           pf("/drafts", { method: "POST", body: params.requestBody }),
       },
     },

--- a/src/gmail-service.ts
+++ b/src/gmail-service.ts
@@ -117,7 +117,7 @@ export function normalizeNulls<T>(obj: T): T {
 }
 
 type MessagePayload = {
-	body?: { data?: string | null; size?: number | null };
+	body?: { attachmentId?: string | null; data?: string | null; size?: number | null };
 	mimeType?: string | null;
 	parts?: MessagePayload[];
 	filename?: string | null;
@@ -262,6 +262,10 @@ export interface GmailServiceOptions {
 export class GmailService {
 	private _accountStorage?: AccountStorage;
 	private configDir?: string;
+	// Returns either a googleapis gmail_v1.Gmail or a proxy client (gmail-proxy-client.ts).
+	// Both implement the same shape but don't share a formal interface — kept as `any`
+	// because all public methods that use it have fully typed inputs and outputs.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	private gmailClients: Map<string, any> = new Map();
 	private inMemoryAccounts: Map<string, EmailAccount> = new Map();
 
@@ -404,6 +408,7 @@ export class GmailService {
 		}
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	private getGmailClient(email: string): any {
 		if (!this.gmailClients.has(email)) {
 			const proxyPath = process.env.GMAIL_PROXY;
@@ -666,7 +671,7 @@ export class GmailService {
 	): Promise<Array<{ id: string; name: string; type: string; textColor?: string; backgroundColor?: string }>> {
 		const gmail = this.getGmailClient(email);
 		const response = await gmail.users.labels.list({ userId: "me" });
-		return (response.data.labels || []).map((l: any) => ({
+		return (response.data.labels || []).map((l: gmail_v1.Schema$Label) => ({
 			id: l.id || "",
 			name: l.name || "",
 			type: l.type || "",
@@ -702,7 +707,7 @@ export class GmailService {
 	): Promise<{ id: string; name: string; type: string; textColor?: string; backgroundColor?: string }> {
 		this.ensureAnyScope(email, [GMAIL_LABELS_SCOPE], "creating labels");
 		const gmail = this.getGmailClient(email);
-		const requestBody: any = {
+		const requestBody: gmail_v1.Schema$Label = {
 			name,
 			labelListVisibility: options.showInList === false ? "labelHide" : "labelShow",
 			messageListVisibility: options.showInMessageList === false ? "hide" : "show",
@@ -748,7 +753,7 @@ export class GmailService {
 		const current = await gmail.users.labels.get({ userId: "me", id: labelId });
 		const currentColor = current.data.color;
 
-		const requestBody: any = {
+		const requestBody: gmail_v1.Schema$Label = {
 			name: options.name || current.data.name,
 		};
 
@@ -788,7 +793,7 @@ export class GmailService {
 			mimeType: string;
 		}> = [];
 
-		const collectAttachments = (payload: any) => {
+		const collectAttachments = (payload: MessagePayload | undefined) => {
 			if (payload?.parts) {
 				for (const part of payload.parts) {
 					if (part.body?.attachmentId && part.filename) {
@@ -868,12 +873,11 @@ export class GmailService {
 
 		const raw = Buffer.from(headers.join("\r\n")).toString("base64url");
 
-		const requestBody: any = {
-			message: { raw },
-		};
+		const message: gmail_v1.Schema$Message = { raw };
 		if (options.threadId) {
-			requestBody.message.threadId = options.threadId;
+			message.threadId = options.threadId;
 		}
+		const requestBody: gmail_v1.Schema$Draft = { message };
 
 		const response = await gmail.users.drafts.create({
 			userId: "me",


### PR DESCRIPTION
## What

Removes every unintentional `any` across the codebase. After this PR, the only remaining `any` are 2 intentional ones (`gmailClients` Map + `getGmailClient` return) with eslint-disable comments explaining why.

## Changes

| File | Fix |
|------|-----|
| `cli.ts` | `result as any[]` → `DownloadedAttachment[]`, remove redundant type annotations on `.find()` callbacks (type inferred from array) |
| `gmail-service.ts` | `requestBody: any` → `gmail_v1.Schema$Label` / `Schema$Draft` / `Schema$Message`, `(l: any)` → `Schema$Label`, `(payload: any)` → `MessagePayload` (added `attachmentId` to body type) |
| `gmail-oauth-flow.ts` | `query: any` → `ParsedUrlQuery` |
| `gmail-proxy-client.ts` | `ProxyFetchOptions` interface, `GmailApiError` interface, `Record<string, unknown>` for requestBody params, `QueryParams` type alias |

## Verification

- `npx tsc --noEmit` — 0 errors
- `bun test` — 96 pass, 0 fail