### PR TITLE
fix: use lazy-init getter in getAccount() to fix account lookup

### DIFF
--- a/src/gmail-service.ts
+++ b/src/gmail-service.ts
@@ -389,7 +389,7 @@ export class GmailService {
 	}
 
 	private getAccount(email: string): EmailAccount {
-		const account = this.inMemoryAccounts.get(email) ?? this._accountStorage?.getAccount(email);
+		const account = this.inMemoryAccounts.get(email) ?? this.accountStorage.getAccount(email);
 		if (!account) {
 			throw new Error(`Account '${email}' not found`);
 		}


### PR DESCRIPTION
## Bug

`getAccount()` uses the private backing field `this._accountStorage?.getAccount(email)` instead of the lazy-init getter `this.accountStorage.getAccount(email)`.

The `_accountStorage` field is only initialized when the `accountStorage` getter is first accessed. Since `getAccount()` bypasses the getter, `_accountStorage` is `undefined` at call time, `undefined?.getAccount(email)` returns `undefined`, and the method throws `Account not found`.

**What works:** `gmail accounts list` — calls `listAccounts()`, which uses `this.accountStorage` (the getter), triggering initialization.

**What breaks:** `gmail --account X search Y`, `gmail --account X thread Z`, and any command that resolves a non-default account via `getAccount()` — all hit the uninitialized backing field.

## Fix

One-character change: `this._accountStorage?.getAccount(email)` → `this.accountStorage.getAccount(email)`.

This routes through the existing lazy-init getter, matching the pattern used by every other method in the class.